### PR TITLE
Increase the maximum "Tile Size" of Mosiac

### DIFF
--- a/plug-ins/common/mosaic.c
+++ b/plug-ins/common/mosaic.c
@@ -648,7 +648,7 @@ mosaic_dialog (GimpDrawable *drawable)
 
   scale_data = gimp_scale_entry_new (GTK_TABLE (table), 0, row++,
                                      _("Tile _size:"), SCALE_WIDTH, 5,
-                                     mvals.tile_size, 5.0, 100.0, 1.0, 10.0, 1,
+                                     mvals.tile_size, 5.0, 512.0, 1.0, 10.0, 1,
                                      TRUE, 0, 0,
                                      NULL, NULL);
   g_signal_connect (scale_data, "value-changed",


### PR DESCRIPTION
It's a simple UI limit preventing the use of Mosiac to make larger tiles... I don't believe it would hurt anything, and it would expand the functionality of Mosiac. 100 pixels, where we are right now, is actually quite small...